### PR TITLE
Add GCP Enterprise example with PSC

### DIFF
--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/README.md
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/README.md
@@ -1,0 +1,21 @@
+### Notes
+
+1. See [Sample Project for Confluent Terraform Provider](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/sample-project) that provides step-by-step instructions of running this example.
+
+2. This example assumes that Terraform is run from a host in the private network, where it will have connectivity to the [Kafka REST API](https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3)) in other words, to the [REST endpoint](https://docs.confluent.io/cloud/current/clusters/broker-config.html#access-cluster-settings-in-the-ccloud-console) on the provisioned Kafka cluster. If it is not, you must make these changes:
+
+    * Update the `confluent_api_key` resources by setting their `disable_wait_for_ready` flag to `true`. Otherwise, Terraform will attempt to validate API key creation by listing topics, which will fail without access to the Kafka REST API. Otherwise, you might see errors like:
+
+        ```
+        Error: error waiting for Kafka API Key "[REDACTED]" to sync: error listing Kafka Topics using Kafka API Key "[REDACTED]": Get "[https://[REDACTED]/kafka/v3/clusters/[REDACTED]/topics](https://[REDACTED]/kafka/v3/clusters/[REDACTED]/topics)": GET [https://[REDACTED]/kafka/v3/clusters/[REDACTED]/topics](https://[REDACTED]/kafka/v3/clusters/[REDACTED]/topics) giving up after 5 attempt(s): Get "[https://[REDACTED]/kafka/v3/clusters/[REDACTED]/topics](https://[REDACTED]/kafka/v3/clusters/[REDACTED/topics)": dial tcp [REDACTED]:443: i/o timeout
+        ```
+
+    * Remove the `confluent_kafka_topic` resource. These resources are provisioned using the Kafka REST API, which is only accessible from the private network.
+
+3. One common deployment workflow for environments with private networking is as follows:
+
+    * A initial (centrally-run) Terraform deployment provisions infrastructure: network, Kafka cluster, and other resources on cloud provider of your choice to setup private network connectivity (like DNS records)
+
+    * A secondary Terraform deployment (run from within the private network) provisions data-plane resources (Kafka Topics and ACLs)
+
+    * Note that RBAC role bindings can be provisioned in either the first or second step, as they are provisioned through the [Confluent Cloud API](https://docs.confluent.io/cloud/current/api.html), not the [Kafka REST API](https://docs.confluent.io/cloud/current/api.html#tag/Topic-(v3))

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/gcp-private-service-connect-endpoint/private-service-connect.tf
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/gcp-private-service-connect-endpoint/private-service-connect.tf
@@ -1,0 +1,66 @@
+locals {
+  dns_domain = var.dns_domain
+}
+
+data "google_compute_network" "psc_endpoint_network" {
+  name = var.customer_vpc_network
+}
+
+data "google_compute_subnetwork" "psc_endpoint_subnetwork" {
+  name = var.customer_subnetwork_name
+}
+
+resource "google_compute_address" "psc_endpoint_ip" {
+  name         = "ccloud-endpoint-ip-${replace(local.dns_domain, ".", "-")}"
+  subnetwork   = var.customer_subnetwork_name
+  address_type = "INTERNAL"
+}
+
+# Private Service Connect endpoint
+resource "google_compute_forwarding_rule" "psc_endpoint_ilb" {
+  name                  = "ccloud-endpoint-${replace(local.dns_domain, ".", "-")}"
+  target                = var.platt_service_attachment_uri
+  load_balancing_scheme = "" # need to override EXTERNAL default when target is a service attachment
+  network               = var.customer_vpc_network
+  ip_address            = google_compute_address.psc_endpoint_ip.id
+}
+
+# Private hosted zone for Private Service Connect endpoints
+resource "google_dns_managed_zone" "psc_endpoint_hz" {
+  name     = "ccloud-endpoint-zone-${replace(local.dns_domain, ".", "-")}"
+  dns_name = "${local.dns_domain}."
+
+  visibility = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = data.google_compute_network.psc_endpoint_network.id
+    }
+  }
+}
+
+resource "google_dns_record_set" "psc_endpoint_rs" {
+  name = "*.${google_dns_managed_zone.psc_endpoint_hz.dns_name}"
+  type = "A"
+  ttl  = 60
+
+  managed_zone = google_dns_managed_zone.psc_endpoint_hz.name
+  rrdatas = [google_compute_address.psc_endpoint_ip.address]
+}
+
+resource "google_compute_firewall" "allow-https-kafka" {
+  name    = "ccloud-fw-${replace(local.dns_domain, ".", "-")}"
+  network = data.google_compute_network.psc_endpoint_network.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443", "9092"]
+  }
+
+  direction          = "EGRESS"
+  destination_ranges = [data.google_compute_subnetwork.psc_endpoint_subnetwork.ip_cidr_range]
+}
+
+output "private_service_connect_connection_id" {
+  value = google_compute_forwarding_rule.psc_endpoint_ilb.psc_connection_id
+}

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/gcp-private-service-connect-endpoint/variables.tf
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/gcp-private-service-connect-endpoint/variables.tf
@@ -1,0 +1,19 @@
+variable "customer_vpc_network" {
+  description = "The VPC network name that you're peering to Confluent Cloud"
+  type        = string
+}
+
+variable "dns_domain" {
+  description = "The root DNS domain for the Private Link Attachment, for example, `pr123a.us-east-2.aws.confluent.cloud`"
+  type        = string
+}
+
+variable "customer_subnetwork_name" {
+  description = "The subnetwork name to provision Private Service Connect endpoint to Confluent Cloud"
+  type        = string
+}
+
+variable "platt_service_attachment_uri" {
+  description = "The Service attachment URI for the PrivateLink Attachment gateway in the Confluent Cloud"
+  type        = string
+}

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/main.tf
@@ -1,0 +1,255 @@
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.1.1"
+    }
+    confluent = {
+      source  = "confluentinc/confluent"
+      version = "2.38.0"
+    }
+  }
+}
+
+provider "confluent" {
+  cloud_api_key    = var.confluent_cloud_api_key
+  cloud_api_secret = var.confluent_cloud_api_secret
+}
+
+# Set GOOGLE_APPLICATION_CREDENTIALS environment variable to a path to a key file
+# for Google TF Provider to work: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#adding-credentials
+provider "google" {
+  project = var.customer_project_id
+  region  = var.region
+}
+
+resource "confluent_environment" "staging" {
+  display_name = "Staging"
+}
+
+resource "confluent_kafka_cluster" "enterprise" {
+  display_name = "inventory"
+  availability = "HIGH"
+  cloud        = "GCP"
+  region       = var.region
+  enterprise {}
+  environment {
+    id = confluent_environment.staging.id
+  }
+}
+
+data "confluent_schema_registry_cluster" "essentials" {
+  environment {
+    id = confluent_environment.staging.id
+  }
+
+  depends_on = [
+    confluent_kafka_cluster.enterprise
+  ]
+}
+
+resource "confluent_private_link_attachment" "pla" {
+  cloud = "GCP"
+  region = var.region
+  display_name = "staging-gcp-platt"
+  environment {
+    id = confluent_environment.staging.id
+  }
+}
+
+module "private-service-connect" {
+  source                       = "./gcp-private-service-connect-endpoint"
+  customer_vpc_network         = var.customer_vpc_network
+  customer_subnetwork_name     = var.customer_subnetwork_name
+  dns_domain                   = confluent_private_link_attachment.pla.dns_domain
+  platt_service_attachment_uri = confluent_private_link_attachment.pla.gcp[0].private_service_connect_service_attachment
+}
+
+resource confluent_private_link_attachment_connection "plac" {
+  display_name = "staging-gcp-plattc"
+  environment {
+    id = confluent_environment.staging.id
+  }
+  gcp {
+    private_service_connect_connection_id = module.private-service-connect.private_service_connect_connection_id
+  }
+  private_link_attachment {
+    id = confluent_private_link_attachment.pla.id
+  }
+}
+
+resource "confluent_service_account" "app-manager" {
+  display_name = "app-manager"
+  description  = "Service account to manage 'inventory' Kafka cluster"
+}
+
+resource "confluent_role_binding" "app-manager-kafka-cluster-admin" {
+  principal   = "User:${confluent_service_account.app-manager.id}"
+  role_name   = "CloudClusterAdmin"
+  crn_pattern = confluent_kafka_cluster.enterprise.rbac_crn
+}
+
+resource "confluent_api_key" "app-manager-kafka-api-key" {
+  display_name = "app-manager-kafka-api-key"
+  description  = "Kafka API Key that is owned by 'app-manager' service account"
+  owner {
+    id          = confluent_service_account.app-manager.id
+    api_version = confluent_service_account.app-manager.api_version
+    kind        = confluent_service_account.app-manager.kind
+  }
+
+  managed_resource {
+    id          = confluent_kafka_cluster.enterprise.id
+    api_version = confluent_kafka_cluster.enterprise.api_version
+    kind        = confluent_kafka_cluster.enterprise.kind
+
+    environment {
+      id = confluent_environment.staging.id
+    }
+  }
+
+  # The goal is to ensure that confluent_role_binding.app-manager-kafka-cluster-admin is created before
+  # confluent_api_key.app-manager-kafka-api-key is used to create instances of
+  # confluent_kafka_topic, confluent_kafka_acl resources.
+
+  # 'depends_on' meta-argument is specified in confluent_api_key.app-manager-kafka-api-key to avoid having
+  # multiple copies of this definition in the configuration which would happen if we specify it in
+  # confluent_kafka_topic, confluent_kafka_acl resources instead.
+  depends_on = [
+    confluent_role_binding.app-manager-kafka-cluster-admin,
+    confluent_private_link_attachment_connection.plac
+  ]
+}
+
+resource "confluent_kafka_topic" "orders" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.enterprise.id
+  }
+  topic_name    = "orders"
+  rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint
+  credentials {
+    key    = confluent_api_key.app-manager-kafka-api-key.id
+    secret = confluent_api_key.app-manager-kafka-api-key.secret
+  }
+}
+
+resource "confluent_service_account" "app-consumer" {
+  display_name = "app-consumer"
+  description  = "Service account to consume from 'orders' topic of 'inventory' Kafka cluster"
+}
+
+resource "confluent_api_key" "app-consumer-kafka-api-key" {
+  display_name = "app-consumer-kafka-api-key"
+  description  = "Kafka API Key that is owned by 'app-consumer' service account"
+  owner {
+    id          = confluent_service_account.app-consumer.id
+    api_version = confluent_service_account.app-consumer.api_version
+    kind        = confluent_service_account.app-consumer.kind
+  }
+
+  managed_resource {
+    id          = confluent_kafka_cluster.enterprise.id
+    api_version = confluent_kafka_cluster.enterprise.api_version
+    kind        = confluent_kafka_cluster.enterprise.kind
+
+    environment {
+      id = confluent_environment.staging.id
+    }
+  }
+
+  depends_on = [
+    confluent_private_link_attachment_connection.plac
+  ]
+}
+
+resource "confluent_kafka_acl" "app-producer-write-on-topic" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.enterprise.id
+  }
+  resource_type = "TOPIC"
+  resource_name = confluent_kafka_topic.orders.topic_name
+  pattern_type  = "LITERAL"
+  principal     = "User:${confluent_service_account.app-producer.id}"
+  host          = "*"
+  operation     = "WRITE"
+  permission    = "ALLOW"
+  rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint
+  credentials {
+    key    = confluent_api_key.app-manager-kafka-api-key.id
+    secret = confluent_api_key.app-manager-kafka-api-key.secret
+  }
+}
+
+resource "confluent_service_account" "app-producer" {
+  display_name = "app-producer"
+  description  = "Service account to produce to 'orders' topic of 'inventory' Kafka cluster"
+}
+
+resource "confluent_api_key" "app-producer-kafka-api-key" {
+  display_name = "app-producer-kafka-api-key"
+  description  = "Kafka API Key that is owned by 'app-producer' service account"
+  owner {
+    id          = confluent_service_account.app-producer.id
+    api_version = confluent_service_account.app-producer.api_version
+    kind        = confluent_service_account.app-producer.kind
+  }
+
+  managed_resource {
+    id          = confluent_kafka_cluster.enterprise.id
+    api_version = confluent_kafka_cluster.enterprise.api_version
+    kind        = confluent_kafka_cluster.enterprise.kind
+
+    environment {
+      id = confluent_environment.staging.id
+    }
+  }
+
+  depends_on = [
+    confluent_private_link_attachment_connection.plac
+  ]
+}
+
+// Note that in order to consume from a topic, the principal of the consumer ('app-consumer' service account)
+// needs to be authorized to perform 'READ' operation on both Topic and Group resources:
+// confluent_kafka_acl.app-consumer-read-on-topic, confluent_kafka_acl.app-consumer-read-on-group.
+// https://docs.confluent.io/platform/current/kafka/authorization.html#using-acls
+resource "confluent_kafka_acl" "app-consumer-read-on-topic" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.enterprise.id
+  }
+  resource_type = "TOPIC"
+  resource_name = confluent_kafka_topic.orders.topic_name
+  pattern_type  = "LITERAL"
+  principal     = "User:${confluent_service_account.app-consumer.id}"
+  host          = "*"
+  operation     = "READ"
+  permission    = "ALLOW"
+  rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint
+  credentials {
+    key    = confluent_api_key.app-manager-kafka-api-key.id
+    secret = confluent_api_key.app-manager-kafka-api-key.secret
+  }
+}
+
+resource "confluent_kafka_acl" "app-consumer-read-on-group" {
+  kafka_cluster {
+    id = confluent_kafka_cluster.enterprise.id
+  }
+  resource_type = "GROUP"
+  // The existing values of resource_name, pattern_type attributes are set up to match Confluent CLI's default consumer group ID ("confluent_cli_consumer_<uuid>").
+  // https://docs.confluent.io/confluent-cli/current/command-reference/kafka/topic/confluent_kafka_topic_consume.html
+  // Update the values of resource_name, pattern_type attributes to match your target consumer group ID.
+  // https://docs.confluent.io/platform/current/kafka/authorization.html#prefixed-acls
+  resource_name = "confluent_cli_consumer_"
+  pattern_type  = "PREFIXED"
+  principal     = "User:${confluent_service_account.app-consumer.id}"
+  host          = "*"
+  operation     = "READ"
+  permission    = "ALLOW"
+  rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint
+  credentials {
+    key    = confluent_api_key.app-manager-kafka-api-key.id
+    secret = confluent_api_key.app-manager-kafka-api-key.secret
+  }
+}

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/outputs.tf
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/outputs.tf
@@ -1,0 +1,41 @@
+output "resource-ids" {
+  value = <<-EOT
+  Environment ID:   ${confluent_environment.staging.id}
+  Kafka Cluster ID: ${confluent_kafka_cluster.enterprise.id}
+  Kafka topic name: ${confluent_kafka_topic.orders.topic_name}
+
+  Service Accounts and their Kafka API Keys (API Keys inherit the permissions granted to the owner):
+  ${confluent_service_account.app-manager.display_name}:                     ${confluent_service_account.app-manager.id}
+  ${confluent_service_account.app-manager.display_name}'s Kafka API Key:     "${confluent_api_key.app-manager-kafka-api-key.id}"
+  ${confluent_service_account.app-manager.display_name}'s Kafka API Secret:  "${confluent_api_key.app-manager-kafka-api-key.secret}"
+
+  ${confluent_service_account.app-producer.display_name}:                    ${confluent_service_account.app-producer.id}
+  ${confluent_service_account.app-producer.display_name}'s Kafka API Key:    "${confluent_api_key.app-producer-kafka-api-key.id}"
+  ${confluent_service_account.app-producer.display_name}'s Kafka API Secret: "${confluent_api_key.app-producer-kafka-api-key.secret}"
+
+  ${confluent_service_account.app-consumer.display_name}:                    ${confluent_service_account.app-consumer.id}
+  ${confluent_service_account.app-consumer.display_name}'s Kafka API Key:    "${confluent_api_key.app-consumer-kafka-api-key.id}"
+  ${confluent_service_account.app-consumer.display_name}'s Kafka API Secret: "${confluent_api_key.app-consumer-kafka-api-key.secret}"
+
+  In order to use the Confluent CLI v2 to produce and consume messages from topic '${confluent_kafka_topic.orders.topic_name}' using Kafka API Keys
+  of ${confluent_service_account.app-producer.display_name} and ${confluent_service_account.app-consumer.display_name} service accounts
+  run the following commands:
+
+  # 1. Log in to Confluent Cloud
+  $ confluent login
+
+  # 2. Produce key-value records to topic '${confluent_kafka_topic.orders.topic_name}' by using ${confluent_service_account.app-producer.display_name}'s Kafka API Key
+  $ confluent kafka topic produce ${confluent_kafka_topic.orders.topic_name} --environment ${confluent_environment.staging.id} --cluster ${confluent_kafka_cluster.enterprise.id} --api-key "${confluent_api_key.app-producer-kafka-api-key.id}" --api-secret "${confluent_api_key.app-producer-kafka-api-key.secret}"
+  # Enter a few records and then press 'Ctrl-C' when you're done.
+  # Sample records:
+  # {"number":1,"date":18500,"shipping_address":"899 W Evelyn Ave, Mountain View, CA 94041, USA","cost":15.00}
+  # {"number":2,"date":18501,"shipping_address":"1 Bedford St, London WC2E 9HG, United Kingdom","cost":5.00}
+  # {"number":3,"date":18502,"shipping_address":"3307 Northland Dr Suite 400, Austin, TX 78731, USA","cost":10.00}
+
+  # 3. Consume records from topic '${confluent_kafka_topic.orders.topic_name}' by using ${confluent_service_account.app-consumer.display_name}'s Kafka API Key
+  $ confluent kafka topic consume ${confluent_kafka_topic.orders.topic_name} --from-beginning --environment ${confluent_environment.staging.id} --cluster ${confluent_kafka_cluster.enterprise.id} --api-key "${confluent_api_key.app-consumer-kafka-api-key.id}" --api-secret "${confluent_api_key.app-consumer-kafka-api-key.secret}"
+  # When you are done, press 'Ctrl-C'.
+  EOT
+
+  sensitive = true
+}

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/terraform.tfvars
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/terraform.tfvars
@@ -1,0 +1,17 @@
+# The GCP Project ID
+customer_project_id = "temp-gear-123456"
+
+# The region of Confluent Cloud Network
+region = "us-central1"
+
+# The VPC network name that you want to connect to Confluent Cloud Cluster
+customer_vpc_network = "default"
+
+# The subnetwork name that you want to connect to Confluent Cloud Cluster
+customer_subnetwork_name = "default"
+
+# Set GOOGLE_APPLICATION_CREDENTIALS environment variable to a path to a key file
+# for Google TF Provider to work: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#adding-credentials
+
+# Limitations of Private Service Connect
+# https://docs.confluent.io/cloud/current/networking/private-links/gcp-private-service-connect.html#limitations

--- a/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/variables.tf
+++ b/examples/configurations/enterprise-private-service-connect-gcp-kafka-acls/variables.tf
@@ -1,0 +1,30 @@
+variable "confluent_cloud_api_key" {
+  description = "Confluent Cloud API Key (also referred as Cloud API ID)."
+  type        = string
+}
+
+variable "confluent_cloud_api_secret" {
+  description = "Confluent Cloud API Secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "customer_project_id" {
+  description = "The GCP Project ID"
+  type        = string
+}
+
+variable "customer_vpc_network" {
+  description = "The VPC network name that you're peering to Confluent Cloud"
+  type        = string
+}
+
+variable "customer_subnetwork_name" {
+  description = "The subnetwork name to provision Private Service Connect endpoint to Confluent Cloud"
+  type        = string
+}
+
+variable "region" {
+  description = "The region of Confluent Cloud Network"
+  type        = string
+}


### PR DESCRIPTION
### Description

This pull request adds a new Terraform example for provisioning a Confluent Cloud enterprise cluster on Google Cloud Platform (GCP) with Private Service Connect (PSC).

The new example follows the established conventions and directory structure used in the existing `aws` and `azure` enterprise examples. It also adheres to the GCP resource conventions from the dedicated cluster PSC example, ensuring consistency and ease of use.

### Key Changes:

-   Adds a new `gcp-enterprise-example` directory.
-   Includes Terraform configuration files (`main.tf`, `variables.tf`, `outputs.tf`) to define and manage the required resources.
-   Configures the private service connect (PSC) setup for secure, private connectivity.

This contribution provides a complete, runnable example for users looking to set up a private Confluent Cloud cluster on GCP.